### PR TITLE
Add instructions for build after re-pull

### DIFF
--- a/new-look/index.html
+++ b/new-look/index.html
@@ -104,6 +104,14 @@ Also, the <code>git&nbsp;status</code> command will tell you if you have modifie
 <p>You can tell if there’s been a check-in to the main git repository by subscribing to the <a href="http://lists.sourceforge.net/lists/listinfo/hol-checkins">hol-checkins mailing list</a>.
 You can check the archives for the list (and see what you might be letting yourself in for) by following the link on the list-info page.</p>
 
+To update an existing install you should perform an additional clean operation:
+
+<pre>
+<code>sml-system &lt; tools/smart-configure.sml</code>
+<code>bin/build cleanAll
+<code>bin/build</code>
+</pre>
+
 <h2>Released versions</h2>
 
 <p>


### PR DESCRIPTION
When I pulled and tried to build again I got an error about not being able to overwrite an existing file:
```
Uploading files to /usr/local/google/home/satnam/HOL/sigobj
Unable to link old file "/usr/local/google/home/satnam/HOL/src/tactictoe/src/infix_file.ui" to new file "/usr/local/google/home/satnam/HOL/sigobj/infix_file.ui": File exists
```
Perhaps it is a good idea to explicitly ask people to perform a `cleanAll` for a re-install.